### PR TITLE
Updated tags()

### DIFF
--- a/api/v1/Shape.js
+++ b/api/v1/Shape.js
@@ -52,10 +52,6 @@ export class Shape {
     return fromGeometry(flip(toKeptGeometry(this)), this.context);
   }
 
-  getTags () {
-    return toGeometry(this).tags;
-  }
-
   op (op, ...args) {
     return op(this, ...args);
   }

--- a/api/v1/tags.js
+++ b/api/v1/tags.js
@@ -2,7 +2,10 @@ import { Shape } from './Shape';
 
 import { allTags } from '@jsxcad/geometry-tagged';
 
-export const tags = (shape) => allTags(shape.toGeometry());
+export const tags = (shape) =>
+  [...allTags(shape.toGeometry())]
+      .filter(tag => tag.startsWith('user/'))
+      .map(tag => tag.substring(5));
 
 const method = function () { return tags(this); };
 


### PR DESCRIPTION
Have Shape.tags() only return 'user/' tags with the namespace removed.

e.g., x.as('y').color('blue').tags() produces ['y'].