### PR TITLE
Freeze top level definitions.

### DIFF
--- a/api/v1-connector/chop.js
+++ b/api/v1-connector/chop.js
@@ -1,6 +1,7 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
 import { getAnySurfaces, getPlans, getSolids } from '@jsxcad/geometry-tagged';
 
+import { Assembly } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 import Z from './Z.js';
 import { cut as bspCut } from '@jsxcad/geometry-bsp';
 import { cut as surfaceCut } from '@jsxcad/geometry-surface';
@@ -65,7 +66,7 @@ export const chop = (shape, connector = Z()) => {
     );
   }
 
-  return assemble(...cuts);
+  return Assembly(...cuts);
 };
 
 const chopMethod = function (surface) {

--- a/api/v1-connector/package.json
+++ b/api/v1-connector/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@jsxcad/api-v1-plan": "^0.0.79",
     "@jsxcad/api-v1-shape": "^0.0.79",
+    "@jsxcad/api-v1-shapes": "^0.0.79",
     "@jsxcad/geometry-bsp": "^0.0.79",
     "@jsxcad/geometry-path": "^0.0.79",
     "@jsxcad/geometry-surface": "^0.0.79",

--- a/api/v1-extrude/ChainedHull.js
+++ b/api/v1-extrude/ChainedHull.js
@@ -1,8 +1,10 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
 import {
   buildConvexHull,
   buildConvexSurfaceHull,
 } from '@jsxcad/algorithm-shape';
+
+import { Assembly } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 
 /**
  *
@@ -41,7 +43,7 @@ export const ChainedHull = (...shapes) => {
       chain.push(Shape.fromGeometry(buildConvexHull(points)));
     }
   }
-  return assemble(...chain);
+  return Assembly(...chain);
 };
 
 const ChainedHullMethod = function (...args) {

--- a/api/v1-extrude/Loop.js
+++ b/api/v1-extrude/Loop.js
@@ -1,4 +1,5 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
+import { Assembly } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 
 import { Y } from '@jsxcad/api-v1-connector';
 import { getPaths } from '@jsxcad/geometry-tagged';
@@ -43,7 +44,7 @@ export const Loop = (
       }
     }
   }
-  return assemble(...solids);
+  return Assembly(...solids);
 };
 
 const LoopMethod = function (...args) {

--- a/api/v1-extrude/extrude.js
+++ b/api/v1-extrude/extrude.js
@@ -1,4 +1,3 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
 import {
   alignVertices,
   transform as transformSolid,
@@ -9,6 +8,8 @@ import {
   transform as transformSurface,
 } from '@jsxcad/geometry-surface';
 
+import { Assembly } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 import { extrude as extrudeAlgorithm } from '@jsxcad/algorithm-shape';
 import { toXYPlaneTransforms } from '@jsxcad/math-plane';
 
@@ -88,7 +89,7 @@ export const extrude = (shape, height = 1, depth = 0) => {
   for (const entry of getPlans(keptGeometry)) {
     solids.push(entry);
   }
-  return assemble(...solids);
+  return Assembly(...solids);
 };
 
 const extrudeMethod = function (...args) {

--- a/api/v1-extrude/fill.js
+++ b/api/v1-extrude/fill.js
@@ -1,10 +1,10 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
 import { getAnySurfaces, getPaths } from '@jsxcad/geometry-tagged';
 import {
   toPlane,
   transform as transformSurface,
 } from '@jsxcad/geometry-surface';
 
+import { Shape } from '@jsxcad/api-v1-shape';
 import { intersectionOfPathsBySurfaces } from '@jsxcad/geometry-z0surface-boolean';
 import { toXYPlaneTransforms } from '@jsxcad/math-plane';
 import { transform as transformPaths } from '@jsxcad/geometry-paths';
@@ -32,7 +32,7 @@ const fillMethod = function (...args) {
 Shape.prototype.fill = fillMethod;
 
 const withFillMethod = function (...args) {
-  return assemble(this, fill(this, ...args));
+  return this.with(fill(this, ...args));
 };
 Shape.prototype.withFill = withFillMethod;
 

--- a/api/v1-extrude/interior.js
+++ b/api/v1-extrude/interior.js
@@ -1,4 +1,5 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
+import { Assembly } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 
 import { getPaths } from '@jsxcad/geometry-tagged';
 import { isClosed } from '@jsxcad/geometry-path';
@@ -40,7 +41,7 @@ export const interior = (shape) => {
       )
     );
   }
-  return assemble(...surfaces);
+  return Assembly(...surfaces);
 };
 
 const interiorMethod = function (...args) {

--- a/api/v1-extrude/outline.js
+++ b/api/v1-extrude/outline.js
@@ -1,5 +1,5 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
-
+import { Assembly } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 import { outline as outlineGeometry } from '@jsxcad/geometry-tagged';
 
 /**
@@ -27,7 +27,7 @@ import { outline as outlineGeometry } from '@jsxcad/geometry-tagged';
  **/
 
 export const outline = (shape) =>
-  assemble(
+  Assembly(
     ...outlineGeometry(shape.toGeometry()).map((outline) =>
       Shape.fromGeometry(outline)
     )
@@ -37,7 +37,7 @@ const outlineMethod = function (options) {
   return outline(this);
 };
 const withOutlineMethod = function (options) {
-  return assemble(this, outline(this));
+  return this.with(outline(this));
 };
 
 Shape.prototype.outline = outlineMethod;

--- a/api/v1-extrude/package.json
+++ b/api/v1-extrude/package.json
@@ -28,6 +28,7 @@
     "@jsxcad/algorithm-toolpath": "^0.0.79",
     "@jsxcad/api-v1-connector": "^0.0.79",
     "@jsxcad/api-v1-shape": "^0.0.79",
+    "@jsxcad/api-v1-shapes": "^0.0.79",
     "@jsxcad/geometry-bsp": "^0.0.79",
     "@jsxcad/geometry-path": "^0.0.79",
     "@jsxcad/geometry-paths": "^0.0.79",

--- a/api/v1-extrude/section.js
+++ b/api/v1-extrude/section.js
@@ -1,6 +1,7 @@
-import { Shape, layer } from '@jsxcad/api-v1-shape';
 import { getPlans, getSolids } from '@jsxcad/geometry-tagged';
 
+import { Layers } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 import { Z } from '@jsxcad/api-v1-connector';
 import { section as bspSection } from '@jsxcad/geometry-bsp';
 import { createNormalize3 } from '@jsxcad/algorithm-quantize';
@@ -78,7 +79,7 @@ export const section = (solidShape, ...connectors) => {
       );
     }
   }
-  return layer(...shapes);
+  return Layers(...shapes);
 };
 
 const sectionMethod = function (...args) {

--- a/api/v1-extrude/stretch.js
+++ b/api/v1-extrude/stretch.js
@@ -1,4 +1,3 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
 import {
   alignVertices,
   transform as transformSolid,
@@ -11,6 +10,8 @@ import {
 } from '@jsxcad/geometry-surface';
 import { getPlans, getSolids } from '@jsxcad/geometry-tagged';
 
+import { Assembly } from '@jsxcad/api-v1-shapes';
+import { Shape } from '@jsxcad/api-v1-shape';
 import { Z } from '@jsxcad/api-v1-connector';
 import { createNormalize3 } from '@jsxcad/algorithm-quantize';
 import { extrude } from '@jsxcad/algorithm-shape';
@@ -79,7 +80,7 @@ export const stretch = (shape, length, connector = Z()) => {
     );
   }
 
-  return assemble(...stretches);
+  return Assembly(...stretches);
 };
 
 const method = function (...args) {

--- a/api/v1-extrude/sweep.js
+++ b/api/v1-extrude/sweep.js
@@ -1,6 +1,6 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
-
+import { Assembly } from '@jsxcad/api-v1-shapes';
 import Hull from './Hull.js';
+import { Shape } from '@jsxcad/api-v1-shape';
 import { getEdges } from '@jsxcad/geometry-path';
 import { getPaths } from '@jsxcad/geometry-tagged';
 
@@ -24,7 +24,7 @@ export const sweep = (toolpath, tool) => {
       );
     }
   }
-  return assemble(...chains);
+  return Assembly(...chains);
 };
 
 const sweepMethod = function (tool) {
@@ -33,7 +33,7 @@ const sweepMethod = function (tool) {
 
 Shape.prototype.sweep = sweepMethod;
 Shape.prototype.withSweep = function (tool) {
-  return assemble(this, sweep(this, tool));
+  return this.with(sweep(this, tool));
 };
 
 export default sweep;

--- a/api/v1-extrude/toolpath.js
+++ b/api/v1-extrude/toolpath.js
@@ -1,4 +1,4 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
+import { Shape } from '@jsxcad/api-v1-shape';
 
 import { toolpath as toolpathAlgorithm } from '@jsxcad/algorithm-toolpath';
 
@@ -18,7 +18,7 @@ const method = function (...options) {
 
 Shape.prototype.toolpath = method;
 Shape.prototype.withToolpath = function (...args) {
-  return assemble(this, toolpath(this, ...args));
+  return this.with(toolpath(this, ...args));
 };
 
 export default toolpath;

--- a/api/v1-extrude/voxels.js
+++ b/api/v1-extrude/voxels.js
@@ -1,10 +1,10 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
 import {
   containsPoint as containsPointAlgorithm,
   fromSolid,
 } from '@jsxcad/geometry-bsp';
 import { getSolids, measureBoundingBox } from '@jsxcad/geometry-tagged';
 
+import { Shape } from '@jsxcad/api-v1-shape';
 import { createNormalize3 } from '@jsxcad/algorithm-quantize';
 import { fromPolygons } from '@jsxcad/geometry-solid';
 
@@ -137,7 +137,7 @@ const surfaceCloudMethod = function (...args) {
 Shape.prototype.surfaceCloud = surfaceCloudMethod;
 
 const withSurfaceCloudMethod = function (...args) {
-  return assemble(this, surfaceCloud(this, ...args));
+  return this.with(surfaceCloud(this, ...args));
 };
 Shape.prototype.withSurfaceCloud = withSurfaceCloudMethod;
 

--- a/api/v1-plans/Label.js
+++ b/api/v1-plans/Label.js
@@ -1,13 +1,12 @@
-import { Shape, assemble } from '@jsxcad/api-v1-shape';
-
 import Plan from '@jsxcad/api-v1-plan';
+import Shape from '@jsxcad/api-v1-shape';
 
 export const Label = (label, mark = [0, 0, 0]) =>
   Plan({ plan: { label }, marks: [mark] });
 Plan.Label = Label;
 
 const withLabelMethod = function (...args) {
-  return assemble(this, Plan.Label(...args));
+  return this.with(Plan.Label(...args));
 };
 Shape.prototype.withLabel = withLabelMethod;
 

--- a/api/v1-shape/Shape.js
+++ b/api/v1-shape/Shape.js
@@ -20,8 +20,6 @@ import {
   transform,
 } from '@jsxcad/geometry-tagged';
 
-import { addReadDecoder } from '@jsxcad/sys';
-
 import { fromPolygons as fromPolygonsToSolid } from '@jsxcad/geometry-solid';
 
 export class Shape {
@@ -158,10 +156,5 @@ export const fromGeometry = Shape.fromGeometry;
 export const toGeometry = (shape) => shape.toGeometry();
 export const toDisjointGeometry = (shape) => shape.toDisjointGeometry();
 export const toKeptGeometry = (shape) => shape.toDisjointGeometry();
-
-addReadDecoder(
-  (data) => data && data.geometry !== undefined,
-  (data) => Shape.fromGeometry(data.geometry)
-);
 
 export default Shape;

--- a/api/v1-shape/main.js
+++ b/api/v1-shape/main.js
@@ -1,97 +1,63 @@
-import './as.js';
 import './add.js';
 import './addTo.js';
+import './as.js';
+import './assemble.js';
+import './canonicalize.js';
+import './center.js';
 import './clip.js';
 import './clipFrom.js';
+import './color.js';
+import './colors.js';
 import './cut.js';
 import './cutFrom.js';
+import './difference.js';
 import './faces.js';
 import './inSolids.js';
+import './intersection.js';
 import './junctions.js';
+import './keep.js';
+import './kept.js';
+import './layer.js';
+import './make.js';
+import './material.js';
 import './measureCenter.js';
+import './move.js';
+import './moveX.js';
+import './moveY.js';
+import './moveZ.js';
 import './noPlan.js';
 import './noVoid.js';
 import './op.js';
 import './openEdges.js';
-import './solids.js';
+import './orient.js';
+import './readShape.js';
+import './rotate.js';
+import './rotateX.js';
+import './rotateY.js';
+import './rotateZ.js';
+import './scale.js';
+import './size.js';
 import './sketch.js';
-import './trace.js';
+import './solids.js';
 import './tags.js';
+import './trace.js';
+import './translate.js';
+import './turn.js';
+import './turnX.js';
+import './turnY.js';
+import './turnZ.js';
+import './union.js';
 import './wall.js';
 import './wireframe.js';
 import './wireframeFaces.js';
 import './with.js';
+import './writeShape.js';
 
-import { drop, keep } from './keep.js';
+import { loadGeometry, saveGeometry } from './saveGeometry.js';
 
 import Shape from './Shape.js';
-import assemble from './assemble.js';
-import canonicalize from './canonicalize.js';
-import center from './center.js';
-import color from './color.js';
-import colors from './colors.js';
-import difference from './difference.js';
-import intersection from './intersection.js';
-import kept from './kept.js';
-import layer from './layer.js';
 import log from './log.js';
-import make from './make.js';
-import material from './material.js';
-import move from './move.js';
-import moveX from './moveX.js';
-import moveY from './moveY.js';
-import moveZ from './moveZ.js';
-import orient from './orient.js';
-import readShape from './readShape.js';
-import rotate from './rotate.js';
-import rotateX from './rotateX.js';
-import rotateY from './rotateY.js';
-import rotateZ from './rotateZ.js';
-import scale from './scale.js';
-import size from './size.js';
-import translate from './translate.js';
-import turn from './turn.js';
-import turnX from './turnX.js';
-import turnY from './turnY.js';
-import turnZ from './turnZ.js';
-import union from './union.js';
-import writeShape from './writeShape.js';
 
-export {
-  Shape,
-  assemble,
-  canonicalize,
-  center,
-  color,
-  colors,
-  difference,
-  drop,
-  intersection,
-  keep,
-  kept,
-  layer,
-  log,
-  make,
-  material,
-  move,
-  moveX,
-  moveY,
-  moveZ,
-  orient,
-  readShape,
-  rotate,
-  rotateX,
-  rotateY,
-  rotateZ,
-  scale,
-  size,
-  translate,
-  turn,
-  turnX,
-  turnY,
-  turnZ,
-  union,
-  writeShape,
-};
+export { Shape, loadGeometry, log, saveGeometry };
 
 export default Shape;

--- a/api/v1-shape/saveGeometry.js
+++ b/api/v1-shape/saveGeometry.js
@@ -1,0 +1,9 @@
+import { read, write } from '@jsxcad/sys';
+
+import Shape from './Shape.js';
+
+export const loadGeometry = async (path) =>
+  Shape.fromGeometry(await read(path));
+
+export const saveGeometry = async (path, shape) =>
+  write(path, shape.toGeometry());

--- a/api/v1-shapes/Difference.js
+++ b/api/v1-shapes/Difference.js
@@ -1,5 +1,3 @@
-import { difference } from '@jsxcad/api-v1-shape';
-
-export const Difference = (...args) => difference(...args);
+export const Difference = (first, ...rest) => first.cut(...rest);
 
 export default Difference;

--- a/api/v1-shapes/Intersection.js
+++ b/api/v1-shapes/Intersection.js
@@ -1,5 +1,3 @@
-import { intersection } from '@jsxcad/api-v1-shape';
-
-export const Intersection = (...args) => intersection(...args);
+export const Intersection = (first, ...rest) => first.clip(...rest);
 
 export default Intersection;

--- a/api/v1-shell/shell.js
+++ b/api/v1-shell/shell.js
@@ -1,5 +1,4 @@
-import { Circle, Sphere } from '@jsxcad/api-v1-shapes';
-import { Shape, assemble, union } from '@jsxcad/api-v1-shape';
+import { Assembly, Circle, Sphere, Union } from '@jsxcad/api-v1-shapes';
 import {
   getAnySurfaces,
   getSolids,
@@ -8,6 +7,7 @@ import {
 } from '@jsxcad/geometry-tagged';
 
 import { Hull } from '@jsxcad/api-v1-extrude';
+import { Shape } from '@jsxcad/api-v1-shape';
 import { getEdges } from '@jsxcad/geometry-path';
 import { toPlane } from '@jsxcad/geometry-surface';
 import { toXYPlaneTransforms } from '@jsxcad/math-plane';
@@ -44,9 +44,9 @@ export const shell = (shape, radius = 1, resolution = 8) => {
         );
       }
     }
-    shells.push(union(...pieces).as(...tags));
+    shells.push(Union(...pieces).as(...tags));
   }
-  assembly.push(union(...shells));
+  assembly.push(Union(...shells));
 
   const faces = [];
   // Handle surface aspects.
@@ -69,14 +69,14 @@ export const shell = (shape, radius = 1, resolution = 8) => {
       }
     }
     faces.push(
-      union(...pieces.map((piece) => piece.transform(from))).as(
+      Union(...pieces.map((piece) => piece.transform(from))).as(
         ...(geometry.tags || [])
       )
     );
   }
-  assembly.push(union(...faces));
+  assembly.push(Union(...faces));
 
-  return assemble(...assembly);
+  return Assembly(...assembly);
 };
 
 const shellMethod = function (radius, resolution) {

--- a/api/v1/api.js
+++ b/api/v1/api.js
@@ -28,7 +28,7 @@ export { Connector, X, Y, Z } from '@jsxcad/api-v1-connector';
 
 export { ChainedHull, Hull, Loop } from '@jsxcad/api-v1-extrude';
 
-export { Shape, log, make } from '@jsxcad/api-v1-shape';
+export { Shape, loadGeometry, log, saveGeometry } from '@jsxcad/api-v1-shape';
 
 export { Line2 } from '@jsxcad/api-v1-line2';
 

--- a/es6/jsxcad-api-v1-connector.js
+++ b/es6/jsxcad-api-v1-connector.js
@@ -1,8 +1,9 @@
-import Shape, { Shape as Shape$1, assemble, log } from './jsxcad-api-v1-shape.js';
+import Shape, { Shape as Shape$1, log } from './jsxcad-api-v1-shape.js';
 import { add, random, scale, dot, subtract, negate } from './jsxcad-math-vec3.js';
 import Plan from './jsxcad-api-v1-plan.js';
 import { visit, getSolids, getAnySurfaces, getPlans, getSurfaces, getZ0Surfaces, toKeptGeometry, drop } from './jsxcad-geometry-tagged.js';
 import { toPlane as toPlane$1, cut as cut$1 } from './jsxcad-geometry-surface.js';
+import { Assembly } from './jsxcad-api-v1-shapes.js';
 import { cut } from './jsxcad-geometry-bsp.js';
 import { toXYPlaneTransforms } from './jsxcad-math-plane.js';
 import { transform } from './jsxcad-geometry-path.js';
@@ -331,7 +332,7 @@ const chop = (shape, connector = Z$1()) => {
     );
   }
 
-  return assemble(...cuts);
+  return Assembly(...cuts);
 };
 
 const chopMethod = function (surface) {

--- a/es6/jsxcad-api-v1-extrude.js
+++ b/es6/jsxcad-api-v1-extrude.js
@@ -1,5 +1,6 @@
-import Shape$1, { Shape, assemble, layer } from './jsxcad-api-v1-shape.js';
 import { buildConvexSurfaceHull, buildConvexHull, loop, extrude as extrude$1, buildConvexMinkowskiSum } from './jsxcad-algorithm-shape.js';
+import { Assembly, Layers } from './jsxcad-api-v1-shapes.js';
+import Shape$1, { Shape } from './jsxcad-api-v1-shape.js';
 import { Y as Y$1, Z as Z$3 } from './jsxcad-api-v1-connector.js';
 import { getPaths, getZ0Surfaces, getSurfaces, getPlans, getAnySurfaces, outline as outline$1, getSolids, taggedLayers, measureBoundingBox } from './jsxcad-geometry-tagged.js';
 import { alignVertices, transform as transform$1, fromPolygons } from './jsxcad-geometry-solid.js';
@@ -52,7 +53,7 @@ const ChainedHull = (...shapes) => {
       chain.push(Shape.fromGeometry(buildConvexHull(points)));
     }
   }
-  return assemble(...chain);
+  return Assembly(...chain);
 };
 
 const ChainedHullMethod = function (...args) {
@@ -155,7 +156,7 @@ const Loop = (
       }
     }
   }
-  return assemble(...solids);
+  return Assembly(...solids);
 };
 
 const LoopMethod = function (...args) {
@@ -239,7 +240,7 @@ const extrude = (shape, height = 1, depth = 0) => {
   for (const entry of getPlans(keptGeometry)) {
     solids.push(entry);
   }
-  return assemble(...solids);
+  return Assembly(...solids);
 };
 
 const extrudeMethod = function (...args) {
@@ -275,7 +276,7 @@ const fillMethod = function (...args) {
 Shape.prototype.fill = fillMethod;
 
 const withFillMethod = function (...args) {
-  return assemble(this, fill(this, ...args));
+  return this.with(fill(this, ...args));
 };
 Shape.prototype.withFill = withFillMethod;
 
@@ -316,7 +317,7 @@ const interior = (shape) => {
       )
     );
   }
-  return assemble(...surfaces);
+  return Assembly(...surfaces);
 };
 
 const interiorMethod = function (...args) {
@@ -383,7 +384,7 @@ minkowski.signature = 'minkowski(a:Shape, b:Shape) -> Shape';
  **/
 
 const outline = (shape) =>
-  assemble(
+  Assembly(
     ...outline$1(shape.toGeometry()).map((outline) =>
       Shape.fromGeometry(outline)
     )
@@ -393,7 +394,7 @@ const outlineMethod = function (options) {
   return outline(this);
 };
 const withOutlineMethod = function (options) {
-  return assemble(this, outline(this));
+  return this.with(outline(this));
 };
 
 Shape.prototype.outline = outlineMethod;
@@ -473,7 +474,7 @@ const section = (solidShape, ...connectors) => {
       );
     }
   }
-  return layer(...shapes);
+  return Layers(...shapes);
 };
 
 const sectionMethod = function (...args) {
@@ -590,7 +591,7 @@ const stretch = (shape, length, connector = Z$3()) => {
     );
   }
 
-  return assemble(...stretches);
+  return Assembly(...stretches);
 };
 
 const method = function (...args) {
@@ -618,7 +619,7 @@ const sweep = (toolpath, tool) => {
       );
     }
   }
-  return assemble(...chains);
+  return Assembly(...chains);
 };
 
 const sweepMethod = function (tool) {
@@ -627,7 +628,7 @@ const sweepMethod = function (tool) {
 
 Shape.prototype.sweep = sweepMethod;
 Shape.prototype.withSweep = function (tool) {
-  return assemble(this, sweep(this, tool));
+  return this.with(sweep(this, tool));
 };
 
 const toolpath = (
@@ -646,7 +647,7 @@ const method$1 = function (...options) {
 
 Shape.prototype.toolpath = method$1;
 Shape.prototype.withToolpath = function (...args) {
-  return assemble(this, toolpath(this, ...args));
+  return this.with(toolpath(this, ...args));
 };
 
 const X = 0;
@@ -778,7 +779,7 @@ const surfaceCloudMethod = function (...args) {
 Shape.prototype.surfaceCloud = surfaceCloudMethod;
 
 const withSurfaceCloudMethod = function (...args) {
-  return assemble(this, surfaceCloud(this, ...args));
+  return this.with(surfaceCloud(this, ...args));
 };
 Shape.prototype.withSurfaceCloud = withSurfaceCloudMethod;
 

--- a/es6/jsxcad-api-v1-plans.js
+++ b/es6/jsxcad-api-v1-plans.js
@@ -1,7 +1,7 @@
 import { Polygon, Circle, Path } from './jsxcad-api-v1-shapes.js';
 import { Hershey } from './jsxcad-api-v1-font.js';
 import Plan from './jsxcad-api-v1-plan.js';
-import { Shape, assemble } from './jsxcad-api-v1-shape.js';
+import Shape from './jsxcad-api-v1-shape.js';
 
 const dp2 = (number) => Math.round(number * 100) / 100;
 
@@ -39,7 +39,7 @@ const Label = (label, mark = [0, 0, 0]) =>
 Plan.Label = Label;
 
 const withLabelMethod = function (...args) {
-  return assemble(this, Plan.Label(...args));
+  return this.with(Plan.Label(...args));
 };
 Shape.prototype.withLabel = withLabelMethod;
 

--- a/es6/jsxcad-api-v1-shapes.js
+++ b/es6/jsxcad-api-v1-shapes.js
@@ -1,5 +1,5 @@
 import { concatenate, rotateZ, translate } from './jsxcad-geometry-path.js';
-import Shape, { difference, intersection } from './jsxcad-api-v1-shape.js';
+import Shape from './jsxcad-api-v1-shape.js';
 import { numbers, linear } from './jsxcad-api-v1-math.js';
 import { taggedAssembly, getAnySurfaces, getPaths, taggedDisjointAssembly, taggedLayers, rewriteTags } from './jsxcad-geometry-tagged.js';
 import { buildRegularPolygon, toRadiusFromApothem as toRadiusFromApothem$1, regularPolygonEdgeLengthToRadius, buildPolygonFromPoints, buildRegularPrism, buildFromFunction, buildFromSlices, buildRegularIcosahedron, buildRingSphere, buildRegularTetrahedron } from './jsxcad-algorithm-shape.js';
@@ -440,7 +440,7 @@ Cylinder.ofSlices.signature =
 Cylinder.ofFunction.signature =
   'Cylinder.ofFunction(op:function, { resolution:number, cap:boolean = true, context:Object }) -> Shape';
 
-const Difference = (...args) => difference(...args);
+const Difference = (first, ...rest) => first.cut(...rest);
 
 const Empty = (...shapes) =>
   Shape.fromGeometry(
@@ -536,7 +536,7 @@ Icosahedron.ofRadius.signature =
 Icosahedron.ofDiameter.signature =
   'Icosahedron.ofDiameter(diameter:number = 1) -> Shape';
 
-const Intersection = (...args) => intersection(...args);
+const Intersection = (first, ...rest) => first.clip(...rest);
 
 const isDefined = (value) => value;
 

--- a/es6/jsxcad-api-v1-shell.js
+++ b/es6/jsxcad-api-v1-shell.js
@@ -1,5 +1,5 @@
-import Shape$1, { union, assemble, Shape } from './jsxcad-api-v1-shape.js';
-import { Sphere, Circle } from './jsxcad-api-v1-shapes.js';
+import Shape$1, { Shape } from './jsxcad-api-v1-shape.js';
+import { Sphere, Union, Circle, Assembly } from './jsxcad-api-v1-shapes.js';
 import { getSolids, getAnySurfaces, outline, transform } from './jsxcad-geometry-tagged.js';
 import { Hull, outline as outline$1 } from './jsxcad-api-v1-extrude.js';
 import { getEdges } from './jsxcad-geometry-path.js';
@@ -38,9 +38,9 @@ const shell = (shape, radius = 1, resolution = 8) => {
         );
       }
     }
-    shells.push(union(...pieces).as(...tags));
+    shells.push(Union(...pieces).as(...tags));
   }
-  assembly.push(union(...shells));
+  assembly.push(Union(...shells));
 
   const faces = [];
   // Handle surface aspects.
@@ -63,14 +63,14 @@ const shell = (shape, radius = 1, resolution = 8) => {
       }
     }
     faces.push(
-      union(...pieces.map((piece) => piece.transform(from))).as(
+      Union(...pieces.map((piece) => piece.transform(from))).as(
         ...(geometry.tags || [])
       )
     );
   }
-  assembly.push(union(...faces));
+  assembly.push(Union(...faces));
 
-  return assemble(...assembly);
+  return Assembly(...assembly);
 };
 
 const shellMethod = function (radius, resolution) {

--- a/es6/jsxcad-api-v1.js
+++ b/es6/jsxcad-api-v1.js
@@ -1,7 +1,7 @@
 import { addPending, write, emit, addSource, read } from './jsxcad-sys.js';
 export { emit, read, write } from './jsxcad-sys.js';
-import Shape, { Shape as Shape$1, log, make } from './jsxcad-api-v1-shape.js';
-export { Shape, log, make } from './jsxcad-api-v1-shape.js';
+import Shape, { Shape as Shape$1, loadGeometry, log, saveGeometry } from './jsxcad-api-v1-shape.js';
+export { Shape, loadGeometry, log, saveGeometry } from './jsxcad-api-v1-shape.js';
 import { ensurePages, Page, pack } from './jsxcad-api-v1-layout.js';
 export { Page, pack } from './jsxcad-api-v1-layout.js';
 import './jsxcad-api-v1-deform.js';
@@ -192,8 +192,9 @@ var api = /*#__PURE__*/Object.freeze({
   Hull: Hull,
   Loop: Loop,
   Shape: Shape$1,
+  loadGeometry: loadGeometry,
   log: log,
-  make: make,
+  saveGeometry: saveGeometry,
   Line2: Line2,
   Plan: Plan,
   Arc: Arc,

--- a/es6/jsxcad-compiler.js
+++ b/es6/jsxcad-compiler.js
@@ -6520,7 +6520,6 @@ const toEcmascript = async (script, { path } = {}) => {
       dependencies.push(node.name);
     };
 
-    // walk(declarator, undefined, { CallExpression, Identifier });
     recursive(declarator, undefined, { Identifier });
 
     const dependencyShas = dependencies.map(fromIdToSha);
@@ -6548,20 +6547,22 @@ const toEcmascript = async (script, { path } = {}) => {
     const meta = await read(`meta/def/${id}`);
     if (meta && meta.sha === sha) {
       const readCode = strip(
-        parse(`await read('data/def/${id}')`, parseOptions)
+        parse(`await loadGeometry('data/def/${id}')`, parseOptions)
       );
       const readExpression = readCode.body[0].expression;
       const init = readExpression;
       out.push({ ...declaration, declarations: [{ ...declarator, init }] });
     } else {
       out.push({ ...declaration, declarations: [declarator] });
+      // Only cache Shapes.
       out.push(
         parse(
-          `await write('data/def/${id}', ${id}) && await write('meta/def/${id}', { sha: '${sha}' });`,
+          `${id} instanceof Shape && await saveGeometry('data/def/${id}', ${id}) && await write('meta/def/${id}', { sha: '${sha}' });`,
           parseOptions
         )
       );
     }
+    out.push(parse(`Object.freeze(${id});`, parseOptions));
   };
 
   for (let nth = 0; nth < body.length; nth++) {

--- a/es6/jsxcad-sys.js
+++ b/es6/jsxcad-sys.js
@@ -3338,38 +3338,6 @@ const write = async (path, data, options = {}) => {
 const { promises: promises$1 } = fs;
 const { deserialize } = v8$1;
 
-// Read decoders allow us to turn data back into objects based on structure.
-const readDecoders = [];
-
-const addReadDecoder = (guard, decoder) =>
-  readDecoders.push({ guard, decoder });
-
-// There should be a better way to do this.
-const decode = (data) => {
-  if (typeof data !== 'object') {
-    return data;
-  }
-  for (const { guard, decoder } of readDecoders) {
-    if (guard(data)) {
-      return decoder(data);
-    }
-  }
-  if (Array.isArray(data)) {
-    // We may have arrays of things to decode.
-    for (let i = 0; i < data.length; i++) {
-      if (typeof data[i] === 'object') {
-        data[i] = decode(data[i]);
-      }
-    }
-  } else if (data.byteLength === undefined) {
-    // We may have objects of things to decode, but not ArrayBuffers.
-    for (let key of Object.keys(data)) {
-      data[key] = decode(data[key]);
-    }
-  }
-  return data;
-};
-
 const getUrlFetcher = async () => {
   if (isBrowser) {
     return window.fetch;
@@ -3495,10 +3463,7 @@ const readFile = async (options, path) => {
   return file.data;
 };
 
-const read = async (path, options = {}) => {
-  const data = await readFile(options, path);
-  return decode(data);
-};
+const read = async (path, options = {}) => readFile(options, path);
 
 const sources = new Map();
 
@@ -3779,4 +3744,4 @@ const touch = async (path, { workspace } = {}) => {
   }
 };
 
-export { addPending, addReadDecoder, addSource, ask, boot, clearEmitted, conversation, createService, deleteFile$1 as deleteFile, emit$1 as emit, getEmitted, getFilesystem, getSources, listFiles$1 as listFiles, listFilesystems, log, onBoot, qualifyPath, read, readFile, resolvePending, setHandleAskUser, setupFilesystem, touch, unwatchFile, unwatchFileCreation, unwatchFileDeletion, unwatchFiles, unwatchLog, watchFile, watchFileCreation, watchFileDeletion, watchLog, write, writeFile };
+export { addPending, addSource, ask, boot, clearEmitted, conversation, createService, deleteFile$1 as deleteFile, emit$1 as emit, getEmitted, getFilesystem, getSources, listFiles$1 as listFiles, listFilesystems, log, onBoot, qualifyPath, read, readFile, resolvePending, setHandleAskUser, setupFilesystem, touch, unwatchFile, unwatchFileCreation, unwatchFileDeletion, unwatchFiles, unwatchLog, watchFile, watchFileCreation, watchFileDeletion, watchLog, write, writeFile };

--- a/sys/main.js
+++ b/sys/main.js
@@ -1,5 +1,5 @@
 export { addPending, resolvePending } from './pending.js';
-export { addReadDecoder, read, readFile } from './readFile.js';
+export { read, readFile } from './readFile.js';
 export { addSource, getSources } from './source.js';
 export { ask, setHandleAskUser } from './ask.js';
 export { boot, onBoot } from './boot.js';

--- a/sys/readFile.js
+++ b/sys/readFile.js
@@ -21,38 +21,6 @@ import { writeFile } from './writeFile.js';
 const { promises } = fs;
 const { deserialize } = v8;
 
-// Read decoders allow us to turn data back into objects based on structure.
-const readDecoders = [];
-
-export const addReadDecoder = (guard, decoder) =>
-  readDecoders.push({ guard, decoder });
-
-// There should be a better way to do this.
-const decode = (data) => {
-  if (typeof data !== 'object') {
-    return data;
-  }
-  for (const { guard, decoder } of readDecoders) {
-    if (guard(data)) {
-      return decoder(data);
-    }
-  }
-  if (Array.isArray(data)) {
-    // We may have arrays of things to decode.
-    for (let i = 0; i < data.length; i++) {
-      if (typeof data[i] === 'object') {
-        data[i] = decode(data[i]);
-      }
-    }
-  } else if (data.byteLength === undefined) {
-    // We may have objects of things to decode, but not ArrayBuffers.
-    for (let key of Object.keys(data)) {
-      data[key] = decode(data[key]);
-    }
-  }
-  return data;
-};
-
 const getUrlFetcher = async () => {
   if (isBrowser) {
     return window.fetch;
@@ -178,7 +146,4 @@ export const readFile = async (options, path) => {
   return file.data;
 };
 
-export const read = async (path, options = {}) => {
-  const data = await readFile(options, path);
-  return decode(data);
-};
+export const read = async (path, options = {}) => readFile(options, path);


### PR DESCRIPTION
Only Shapes are cached.
Removed read decoders.
Cleaned up api.