### PR TITLE
Expose axis and grid options in orbitDisplay

### DIFF
--- a/ui/threejs/orbitDisplay.js
+++ b/ui/threejs/orbitDisplay.js
@@ -10,7 +10,7 @@ import { moveToFit } from './moveToFit.js';
 import { toThreejsGeometry } from '@jsxcad/convert-threejs';
 
 export const orbitDisplay = async (
-  { view = {}, geometry, canvas } = {},
+  { view = {}, geometry, canvas, withAxes = false } = {},
   page
 ) => {
   let datasets = [];
@@ -30,7 +30,7 @@ export const orbitDisplay = async (
     view,
     geometryLayers,
     planLayers,
-    withAxes: false,
+    withAxes,
   });
 
   const render = () => {

--- a/ui/threejs/orbitDisplay.js
+++ b/ui/threejs/orbitDisplay.js
@@ -10,7 +10,7 @@ import { moveToFit } from './moveToFit.js';
 import { toThreejsGeometry } from '@jsxcad/convert-threejs';
 
 export const orbitDisplay = async (
-  { view = {}, geometry, canvas, withAxes = false } = {},
+  { view = {}, geometry, canvas, withAxes = false, withGrid = false } = {},
   page
 ) => {
   let datasets = [];
@@ -31,6 +31,7 @@ export const orbitDisplay = async (
     geometryLayers,
     planLayers,
     withAxes,
+    withGrid,
   });
 
   const render = () => {


### PR DESCRIPTION
Exposes orbitDisplay options to add a grid or axis. The default behavior is to display neither which is the way things were before this change.