### PR TITLE
Display grid even if fit = false

### DIFF
--- a/ui/threejs/moveToFit.js
+++ b/ui/threejs/moveToFit.js
@@ -10,10 +10,6 @@ export const moveToFit = ({
 } = {}) => {
   const { fit = true } = view;
 
-  if (!fit) {
-    return;
-  }
-
   let box;
 
   scene.traverse((object) => {
@@ -61,6 +57,10 @@ export const moveToFit = ({
       grid.layers.set(1);
       scene.add(grid);
     }
+  }
+
+  if (!fit) {
+    return;
   }
 
   const center = box.getCenter(new Vector3());


### PR DESCRIPTION
I am not 100% sure this is the right way to do this, but I figured better to at least try to make a pull request than ask you to change it. 

Basically if the fit setting was turned off in an orbitDisplay then the moveToFit function was returning before the grid was generated. This change moves that return until after the grid has been created.

