### PR TITLE
Adjust thread to respond to pitch more dynamically

### DIFF
--- a/nb/projects/bolt/bolt.nb
+++ b/nb/projects/bolt/bolt.nb
@@ -1,18 +1,19 @@
-const Profile = (pitch = 1, angle = 60 / 360) =>
+const Profile = (pitch = 1, depth = 4 / 3) =>
   Path(
     Point(0, 0),
-    Point(pitch / -2, 1.33 * pitch),
-    Point(pitch / 2, 1.33 * pitch),
+    Point(pitch / -2, depth),
+    Point(pitch / 2, depth),
     Point(0, 0)
   ).fill();
 
 export const ScrewThread = (
   diameter,
   height,
-  { pitch = 1, angle, play = 0.1, lefthanded = false } = {}
-) =>
-  Profile(pitch, angle)
-    .y(diameter / -2 + play * 2 - 0.5 * pitch)
+  { pitch = 1, angle = 60 / 360, play = 0.01, lefthanded = false } = {}
+) => {
+  const depth = pitch / 2 / Math.tan(angle * Math.PI);
+  return Profile(pitch, depth)
+    .y(diameter / -2 - depth / 4)
     .ry(1 / 4)
     .loft(
       seq((t) => (s) => s.rz(t).z(pitch * t * 1.001), {
@@ -25,38 +26,30 @@ export const ScrewThread = (
     .clip(Box(diameter).ex(pitch))
     .z(seq((a) => a, { from: 0, to: height, by: pitch }))
     .clip(Arc(diameter).ex(height))
-    .and(Arc(diameter - 1.33 * pitch).ex(height));
+    .and(Arc(diameter - depth).ex(height));
+};
 
 export const NutThread = (
   diameter,
   height,
-  { pitch = 1, angle, play = 0.1, lefthanded = false } = {}
-) =>
-  Profile(pitch, angle)
-    .rz(1 / 2)
-    .y(diameter / -2 + 1 / 2 - play * 2)
-    .ry(1 / 4)
-    .loft(
-      seq((t) => (s) => s.rz(t).z(pitch * t * 1.001), {
-        from: -1 / 2,
-        by: 1 / 32,
-        to: 3 / 2,
-      })
-    )
-    .scale(lefthanded ? 1 : -1, lefthanded ? 1 : -1, 1)
-    .clip(Box(diameter + 2).ex(pitch))
+  { pitch = 2, angle = 60 / 360, play = 0.1, lefthanded = false } = {}
+) => {
+  const screwThread = ScrewThread(diameter, pitch, {
+    pitch: pitch,
+    angle: angle,
+    play: -1 * play,
+  }).view();
+  const depth = pitch / 2 / Math.tan(angle * Math.PI);
+  return Arc(diameter + 2 * pitch)
+    .ex(pitch)
+    .cut(screwThread)
     .z(seq((a) => a, { from: 0, to: height, by: pitch }))
-    .clip(Box(diameter + 2).ex(height))
-    .rz(1 / 2)
-    .mask(Arc(diameter).ex(height));
+    .clip(Box(diameter + 2 * pitch).ex(height));
+};
 
-const profile = Profile().view();
+const nutThread = NutThread(20, 10).material('steel').stl('nut 20x10');
 
-const nutThread = NutThread(20, 10)
-  .material('steel')
-  .stl('nut 20x10');
-
-const screwThread = ScrewThread(20, 10)
+const screwThread = ScrewThread(20, 10, { pitch: 2 })
   .cut(
     Box(2, 10)
       .ex(10, 5)
@@ -66,7 +59,18 @@ const screwThread = ScrewThread(20, 10)
   .stl('thread 20x10');
 
 md`Show the fit.`;
-ScrewThread(10, 5)
-  .and(NutThread(10, 5).and(Arc(15).cut(Arc(10)).ex(5)))
-  .view(1)
-  .view(2, section());
+ScrewThread(20, 10, { pitch: 2, play: 0 }).material('steel').view();
+
+NutThread(20, 10, { pitch: 1, play: 0 }).material('steel').view();
+
+Group(
+  ScrewThread(20, 10, { pitch: 2, play: 0 }).material('steel'),
+  NutThread(20, 10, { pitch: 2, play: 0 }).material('steel')
+)
+  .cut(Box(500, 500, 500).x(250))
+  .view();
+
+//ScrewThread(10, 5)
+//  .and(NutThread(10, 5).and(Arc(15).cut(Arc(10)).ex(5)))
+//  .view(1)
+//  .view(2, section());

--- a/nb/projects/bolt/bolt.nb
+++ b/nb/projects/bolt/bolt.nb
@@ -1,9 +1,9 @@
 const Profile = (pitch = 1, angle = 60 / 360) =>
   Path(
-    Point(0, 1 / -2),
-    Point(pitch / -2, 1 / 2),
-    Point(pitch / 2, 1 / 2),
-    Point(0, 1 / -2)
+    Point(0, 0),
+    Point(pitch / -2, 1.33 * pitch),
+    Point(pitch / 2, 1.33 * pitch),
+    Point(0, 0)
   ).fill();
 
 export const ScrewThread = (
@@ -12,7 +12,7 @@ export const ScrewThread = (
   { pitch = 1, angle, play = 0.1, lefthanded = false } = {}
 ) =>
   Profile(pitch, angle)
-    .y(diameter / -2 + 1 / 2 + play * 2)
+    .y(diameter / -2 + play * 2 - 0.5 * pitch)
     .ry(1 / 4)
     .loft(
       seq((t) => (s) => s.rz(t).z(pitch * t * 1.001), {
@@ -24,8 +24,8 @@ export const ScrewThread = (
     .scale(lefthanded ? 1 : -1, lefthanded ? 1 : -1, 1)
     .clip(Box(diameter).ex(pitch))
     .z(seq((a) => a, { from: 0, to: height, by: pitch }))
-    .clip(Box(diameter).ex(height))
-    .and(Arc(diameter - 2).ex(height));
+    .clip(Arc(diameter).ex(height))
+    .and(Arc(diameter - 1.33 * pitch).ex(height));
 
 export const NutThread = (
   diameter,

--- a/nb/projects/bolt/bolt.nb
+++ b/nb/projects/bolt/bolt.nb
@@ -12,7 +12,7 @@ export const ScrewThread = (
   { pitch = 1, angle = 60 / 360, play = 0.01, lefthanded = false } = {}
 ) => {
   const depth = pitch / 2 / Math.tan(angle * Math.PI);
-  return Profile(pitch, depth)
+  const thread = Profile(pitch, depth)
     .y(diameter / -2 - depth / 4)
     .ry(1 / 4)
     .loft(
@@ -22,11 +22,15 @@ export const ScrewThread = (
         to: 3 / 2,
       })
     )
-    .scale(lefthanded ? 1 : -1, lefthanded ? 1 : -1, 1)
     .clip(Box(diameter).ex(pitch))
     .z(seq((a) => a, { from: 0, to: height, by: pitch }))
     .clip(Arc(diameter).ex(height))
     .and(Arc(diameter - depth).ex(height));
+  if (lefthanded) {
+    return thread.scale(1, 1, -1).z(height);
+  } else {
+    return thread;
+  }
 };
 
 export const NutThread = (
@@ -57,6 +61,13 @@ const screwThread = ScrewThread(20, 10, { pitch: 2 })
   )
   .material('steel')
   .stl('thread 20x10');
+
+md`Left hand vs right hand.`;
+
+Group(
+  ScrewThread(5, 5, { pitch: 0.5, lefthanded: true }).x(-3),
+  ScrewThread(5, 5, { pitch: 0.5, lefthanded: false }).x(3)
+).view();
 
 md`Show the fit.`;
 ScrewThread(20, 10, { pitch: 2, play: 0 }).material('steel').view();


### PR DESCRIPTION
These are my thoughts on tweaking how threads work. I don't think it's finished, but it seems like a step in the right direction. 

These changes create threads which will always have a bounding cylinder which matches the input diameter and height (they were slightly off before). The threads also now have a more traditional profile with a flattened bit on the innermost part and the outermost part.

![image](https://user-images.githubusercontent.com/9359447/145940644-fddc0a02-ee22-417f-a3e4-bb173f24a509.png)

The pitch now changes the size of the tooth to maintain a 60 degree tooth angle. It would probably be nice if that was a user input really.

Here's a pitch of 1:

<img width="464" alt="image" src="https://user-images.githubusercontent.com/9359447/145941145-ae94bbcf-1965-41d4-a666-2289e52cd8d4.png">

And here's a pitch of 3:

<img width="496" alt="image" src="https://user-images.githubusercontent.com/9359447/145941321-c04d9146-6d0e-4763-996c-3d8ebfede658.png">

I haven't messed with nut threads yet, but I'll do those in the morning if this seems like the way to go.
