### PR TITLE
Revert "Bump node-fetch from 2.3.0 to 2.6.7"

### DIFF
--- a/sys/package.json
+++ b/sys/package.json
@@ -28,7 +28,7 @@
     "digest-js": "^0.3.0",
     "idb": "^7.0.0",
     "idb-keyval": "^6.0.3",
-    "node-fetch": "^2.6.7",
+    "node-fetch": "^3.2.0",
     "nanoid": "^3.1.16"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts jsxcad/JSxCAD#1106